### PR TITLE
FIX inconsiderate removal of YEARLY frequency spinner item which causes IndexOutOfBoundsException when displaying 'Custom' picker view carrying YEARLY frequency.

### DIFF
--- a/Library/src/main/java/com/teambition/recurrencerule/RecurrenceOptionsCreator.java
+++ b/Library/src/main/java/com/teambition/recurrencerule/RecurrenceOptionsCreator.java
@@ -135,7 +135,7 @@ public class RecurrenceOptionsCreator extends FrameLayout implements AdapterView
         mIntervalSpinner = (Spinner) findViewById(R.id.intevalSpinner);
         mIntervalSpinner.setOnItemSelectedListener(this);
 
-        String[] intervalStrs = new String[7];
+        String[] intervalStrs = new String[999];
         for (int i = 0, length = intervalStrs.length; i < length; i++) {
             intervalStrs[i] = String.valueOf(i + 1);
         }

--- a/Library/src/main/res/values-zh/arrays.xml
+++ b/Library/src/main/res/values-zh/arrays.xml
@@ -4,5 +4,6 @@
         <item>每天</item>
         <item>每周</item>
         <item>每月</item>
+        <item>每年</item>
     </string-array>
 </resources>

--- a/Library/src/main/res/values/arrays.xml
+++ b/Library/src/main/res/values/arrays.xml
@@ -14,5 +14,6 @@
         <item>REPEAT DAILY</item>
         <item>REPEAT WEEKLY</item>
         <item>REPEAT MONTHLY</item>
+        <item>REPEAT YEARLY</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Done by reverting "update: remove custom yearly recurrency, change range to 1-7"